### PR TITLE
bugfix: s/path/url/

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ tag, branch, or commit.
 external_components:
   - source:
       type: git
-      path: https://github.com/trombik/esphome-component-ping
+      url: https://github.com/trombik/esphome-component-ping
       ref: main
 ```
 


### PR DESCRIPTION
recent esphome needs url instead of path