### PR TITLE
ci: update esphome to 2022.9.4

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-esphome = "2022.3.1"
+esphome = "2022.9.4"
 
 [dev-packages]
 pylint = "2.8.2"


### PR DESCRIPTION
because platformio refuses to serve when platformio is older than version 6.

> Error: Please upgrade to the PlatformIO Core 6