### PR TITLE
Increase `task stack size` for ESP32 Ping to 2560

### DIFF
--- a/components/ping/ping_esp32.h
+++ b/components/ping/ping_esp32.h
@@ -149,6 +149,7 @@ class PingSensorESP32 : public PingSensor {
 
     ping_config.target_addr = target_addr;
     ping_config.count = n_packet;
+    ping_config.task_stack_size = 4096;
 
     cbs.on_ping_success = PingSensorESP32::cb_ping_on_ping_success;
     cbs.on_ping_timeout = PingSensorESP32::cb_cmd_ping_on_ping_timeout;

--- a/components/ping/ping_esp32.h
+++ b/components/ping/ping_esp32.h
@@ -149,7 +149,7 @@ class PingSensorESP32 : public PingSensor {
 
     ping_config.target_addr = target_addr;
     ping_config.count = n_packet;
-    ping_config.task_stack_size = 4096;
+    ping_config.task_stack_size = 2560;
 
     cbs.on_ping_success = PingSensorESP32::cb_ping_on_ping_success;
     cbs.on_ping_timeout = PingSensorESP32::cb_cmd_ping_on_ping_timeout;


### PR DESCRIPTION
Insufficient stack size leads to connection losses.
Fix https://github.com/trombik/esphome-component-ping/issues/40